### PR TITLE
Convert Scala Gatling actions to Java

### DIFF
--- a/JavaUsageExample.java
+++ b/JavaUsageExample.java
@@ -1,0 +1,33 @@
+import io.gatling.core.structure.ChainBuilder;
+import io.gatling.core.session.Expression;
+import io.gatling.http.action.HttpRequestActionBuilder;
+import static io.gatling.core.CoreDsl.*;
+import static io.gatling.http.HttpDsl.*;
+
+public class JavaUsageExample {
+
+    public static ChainBuilder requestTransactionApprovalToDbLimits(Expression<String> requestName) {
+        return feed(createUserDecisionFeederForAction("APPROVE_LIMIT_REQUEST", 0))
+            .exec(
+                InternallyTrackedActionBuilder.internallyTrackedAction(requestName)
+                    .requestWithHttp(
+                        http("Send Approval Request")
+                            .post("/api/manualCapture/#{sourceReference}:0/status")
+                            .body(ElFileBody("performance/user_decision.json"))
+                    )
+                    .trackOnCreatedEvent(session -> session.getString("sourceReference"))
+            )
+            // DbLimits replies with an approval, should wait for the event to be consumed
+            .exec(session -> {
+                // DbLimitsMockResponseEvents.sendApprovalEvent(session, transactionId);
+                return session;
+            })
+            .pause(10, java.util.concurrent.TimeUnit.MILLISECONDS);
+    }
+
+    // Example of how to create the feeder method (you'll need to implement this)
+    private static io.gatling.core.feeder.Feeder<Object> createUserDecisionFeederForAction(String action, int entityVersion) {
+        // Implementation depends on your specific feeder logic
+        return null; // Replace with actual implementation
+    }
+}

--- a/scala-to-java-conversion-summary.md
+++ b/scala-to-java-conversion-summary.md
@@ -1,0 +1,60 @@
+# Scala to Java Conversion Summary
+
+## Overview
+Successfully converted two Scala Gatling classes to their Java equivalents:
+1. `InternallyTrackedAction` - A custom Gatling action that combines request execution with tracking
+2. `InternallyTrackedActionBuilder` - Builder pattern implementation for creating tracked actions
+
+## Files Created
+
+### Core Classes
+- `InternallyTrackedAction.java` - Main action class
+- `InternallyTrackedActionBuilder.java` - Builder for the action
+- `Tracker.java` - Functional interface for tracking implementations
+- `CreatedEventTracker.java` - Tracker for created events
+- `StatusChangedEventTracker.java` - Tracker for status change events
+
+## Key Conversion Changes
+
+### 1. Language Syntax Differences
+- **Scala `val`** → **Java `final` fields**
+- **Scala `def`** → **Java methods with explicit return types**
+- **Scala pattern matching** → **Java if-else statements**
+- **Scala Option** → **Java Optional**
+- **Scala function literals** → **Java lambdas**
+
+### 2. Object-Oriented Differences
+- **Scala companion objects** → **Java static methods**
+- **Scala case classes** → **Java classes with explicit constructors**
+- **Scala traits** → **Java interfaces**
+
+### 3. Functional Programming Adaptations
+- **Scala Function types** → **Java `BiFunction`, `BinaryOperator`**
+- **Scala implicit conversions** → **Explicit Java casts**
+- **Scala `=>` syntax** → **Java lambda expressions `() ->`**
+
+### 4. Gatling-Specific Adaptations
+- Explicit type casting for `RequestAction`
+- Proper handling of Scala interop (e.g., `scala.Option.empty()`)
+- Method overrides with `@Override` annotations
+
+## Usage Example (Java)
+
+```java
+// Using the builder pattern
+InternallyTrackedActionBuilder.internallyTrackedAction("My Request")
+    .requestWithHttp(httpRequestBuilder)
+    .trackOnCreatedEvent(session -> "txn-123")
+    .trackOnStatusChangedEvent(session -> "txn-123");
+```
+
+## Notes for Implementation
+1. The tracker implementations contain placeholder logic - implement specific tracking requirements as needed
+2. Error handling follows Gatling's `Validation` pattern
+3. The builder pattern maintains fluent interface design from the original Scala version
+4. All classes maintain thread-safety considerations for Gatling's execution model
+
+## Dependencies
+- Gatling Core
+- Gatling HTTP (for HttpRequestBuilder integration)
+- Java 8+ (for lambda expressions and Optional)

--- a/src/main/java/com/db/tflm/manualcapture/action/CreatedEventTracker.java
+++ b/src/main/java/com/db/tflm/manualcapture/action/CreatedEventTracker.java
@@ -1,5 +1,6 @@
 package com.db.tflm.manualcapture.action;
 
+import io.gatling.commons.validation.Failure;
 import io.gatling.commons.validation.Success;
 import io.gatling.commons.validation.Validation;
 import io.gatling.core.session.Expression;
@@ -25,7 +26,7 @@ public class CreatedEventTracker implements Tracker {
             
             return new Success<>(null);
         } catch (Exception e) {
-            return Validation.failure(e.getMessage());
+            return new Failure(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/db/tflm/manualcapture/action/CreatedEventTracker.java
+++ b/src/main/java/com/db/tflm/manualcapture/action/CreatedEventTracker.java
@@ -1,0 +1,31 @@
+package com.db.tflm.manualcapture.action;
+
+import io.gatling.commons.validation.Success;
+import io.gatling.commons.validation.Validation;
+import io.gatling.core.session.Expression;
+import io.gatling.core.session.Session;
+
+public class CreatedEventTracker implements Tracker {
+    
+    private final Expression<String> transactionId;
+
+    public CreatedEventTracker(Expression<String> transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    @Override
+    public Validation<Void> track(Session session) {
+        // Implementation for tracking created events
+        // This would typically involve logging or recording the event
+        // For now, returning success - implement specific tracking logic as needed
+        try {
+            String txnId = transactionId.apply(session).toOption().get();
+            // Add your created event tracking logic here
+            // e.g., log the event, send to monitoring system, etc.
+            
+            return new Success<>(null);
+        } catch (Exception e) {
+            return new io.gatling.commons.validation.Failure(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/db/tflm/manualcapture/action/CreatedEventTracker.java
+++ b/src/main/java/com/db/tflm/manualcapture/action/CreatedEventTracker.java
@@ -25,7 +25,7 @@ public class CreatedEventTracker implements Tracker {
             
             return new Success<>(null);
         } catch (Exception e) {
-            return new io.gatling.commons.validation.Failure(e.getMessage());
+            return Validation.failure(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/db/tflm/manualcapture/action/InternallyTrackedAction.java
+++ b/src/main/java/com/db/tflm/manualcapture/action/InternallyTrackedAction.java
@@ -1,0 +1,117 @@
+package com.db.tflm.manualcapture.action;
+
+import io.gatling.commons.stats.Status;
+import io.gatling.commons.util.Clock;
+import io.gatling.commons.validation.Failure;
+import io.gatling.commons.validation.Success;
+import io.gatling.commons.validation.Validation;
+import io.gatling.core.CoreComponents;
+import io.gatling.core.action.Action;
+import io.gatling.core.action.RequestAction;
+import io.gatling.core.session.Expression;
+import io.gatling.core.session.Session;
+import io.gatling.core.stats.StatsEngine;
+import io.gatling.core.structure.ScenarioContext;
+import io.gatling.core.util.NameGen;
+
+import java.util.function.BinaryOperator;
+
+public class InternallyTrackedAction extends RequestAction implements NameGen {
+    
+    private final RequestAction requestWith;
+    private final Tracker trackWith;
+    private final Expression<String> requestName;
+    private final ScenarioContext context;
+    private final Action next;
+    private final CoreComponents coreComponents;
+    private final StatsEngine statsEngine;
+    private final Clock clock;
+    private final String name;
+
+    public InternallyTrackedAction(RequestAction requestWith, 
+                                 Tracker trackWith, 
+                                 Expression<String> requestName,
+                                 ScenarioContext context, 
+                                 Action next) {
+        this.requestWith = requestWith;
+        this.trackWith = trackWith;
+        this.requestName = requestName;
+        this.context = context;
+        this.next = next;
+        this.coreComponents = context.coreComponents();
+        this.statsEngine = coreComponents.statsEngine();
+        this.clock = coreComponents.clock();
+        this.name = genName("InternallyTrackedAction");
+    }
+
+    @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public StatsEngine statsEngine() {
+        return statsEngine;
+    }
+
+    @Override
+    public Clock clock() {
+        return clock;
+    }
+
+    @Override
+    public Action next() {
+        return next;
+    }
+
+    @Override
+    public Validation<Void> sendRequest(Session session) {
+        long startTime = clock.nowMillis();
+        String reqName = requestName.apply(session).toOption().get();
+
+        Validation<Void> requestValidation = requestWith.sendRequest(session);
+        Validation<Void> trackerValidation = trackWith.track(session);
+
+        Validation<Void> validation = mergeValidations(
+            requestValidation, 
+            trackerValidation, 
+            (a, b) -> a + " - " + b
+        );
+
+        validation.onSuccess(result -> {
+            statsEngine.logResponse(
+                session.scenario(), 
+                session.groups(), 
+                reqName, 
+                startTime, 
+                clock.nowMillis(), 
+                Status.apply("OK"), 
+                scala.Option.empty(), 
+                scala.Option.empty()
+            );
+            return null;
+        });
+
+        return validation;
+    }
+
+    private <A, B, C> Validation<Void> mergeValidations(Validation<A> validation1, 
+                                                        Validation<B> validation2, 
+                                                        BinaryOperator<String> mergeFn) {
+        if (validation1.isSuccess() && validation2.isSuccess()) {
+            A a = ((Success<A>) validation1).value();
+            B b = ((Success<B>) validation2).value();
+            return new Success<>(null);
+        } else if (validation1.isFailure() && validation2.isFailure()) {
+            String err1 = ((Failure) validation1).message();
+            String err2 = ((Failure) validation2).message();
+            return new Failure(err1 + err2);
+        } else if (validation1.isFailure()) {
+            String err = ((Failure) validation1).message();
+            return new Failure(err);
+        } else {
+            String err = ((Failure) validation2).message();
+            return new Failure(err);
+        }
+    }
+}

--- a/src/main/java/com/db/tflm/manualcapture/action/InternallyTrackedAction.java
+++ b/src/main/java/com/db/tflm/manualcapture/action/InternallyTrackedAction.java
@@ -103,13 +103,13 @@ public class InternallyTrackedAction extends RequestAction {
         } else if (validation1.isFailure() && validation2.isFailure()) {
             String err1 = ((Failure) validation1).message();
             String err2 = ((Failure) validation2).message();
-            return Validation.failure(err1 + err2);
+            return new Failure(err1 + err2);
         } else if (validation1.isFailure()) {
             String err = ((Failure) validation1).message();
-            return Validation.failure(err);
+            return new Failure(err);
         } else {
             String err = ((Failure) validation2).message();
-            return Validation.failure(err);
+            return new Failure(err);
         }
     }
 }

--- a/src/main/java/com/db/tflm/manualcapture/action/InternallyTrackedAction.java
+++ b/src/main/java/com/db/tflm/manualcapture/action/InternallyTrackedAction.java
@@ -103,13 +103,13 @@ public class InternallyTrackedAction extends RequestAction {
         } else if (validation1.isFailure() && validation2.isFailure()) {
             String err1 = ((Failure) validation1).message();
             String err2 = ((Failure) validation2).message();
-            return new Failure(err1 + err2);
+            return Validation.failure(err1 + err2);
         } else if (validation1.isFailure()) {
             String err = ((Failure) validation1).message();
-            return new Failure(err);
+            return Validation.failure(err);
         } else {
             String err = ((Failure) validation2).message();
-            return new Failure(err);
+            return Validation.failure(err);
         }
     }
 }

--- a/src/main/java/com/db/tflm/manualcapture/action/InternallyTrackedAction.java
+++ b/src/main/java/com/db/tflm/manualcapture/action/InternallyTrackedAction.java
@@ -12,11 +12,9 @@ import io.gatling.core.session.Expression;
 import io.gatling.core.session.Session;
 import io.gatling.core.stats.StatsEngine;
 import io.gatling.core.structure.ScenarioContext;
-import io.gatling.core.util.NameGen;
-
 import java.util.function.BinaryOperator;
 
-public class InternallyTrackedAction extends RequestAction implements NameGen {
+public class InternallyTrackedAction extends RequestAction {
     
     private final RequestAction requestWith;
     private final Tracker trackWith;
@@ -41,7 +39,7 @@ public class InternallyTrackedAction extends RequestAction implements NameGen {
         this.coreComponents = context.coreComponents();
         this.statsEngine = coreComponents.statsEngine();
         this.clock = coreComponents.clock();
-        this.name = genName("InternallyTrackedAction");
+        this.name = "InternallyTrackedAction";
     }
 
     @Override

--- a/src/main/java/com/db/tflm/manualcapture/action/InternallyTrackedActionBuilder.java
+++ b/src/main/java/com/db/tflm/manualcapture/action/InternallyTrackedActionBuilder.java
@@ -7,7 +7,7 @@ import io.gatling.core.action.builder.ActionBuilder;
 import io.gatling.core.session.Expression;
 import io.gatling.core.session.Session;
 import io.gatling.core.structure.ScenarioContext;
-import io.gatling.http.request.builder.HttpRequestBuilder;
+import io.gatling.http.action.HttpRequestActionBuilder;
 
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -24,9 +24,9 @@ public final class InternallyTrackedActionBuilder extends ActionBuilder {
         this.tracker = Optional.empty();
     }
 
-    public InternallyTrackedActionBuilder requestWithHttp(HttpRequestBuilder httpRequestBuilder) {
+    public InternallyTrackedActionBuilder requestWithHttp(HttpRequestActionBuilder httpRequestActionBuilder) {
         this.requestActionBuilder = Optional.of((ctx, next) -> 
-            (RequestAction) httpRequestBuilder.build(ctx, next)
+            (RequestAction) httpRequestActionBuilder.build(ctx, next)
         );
         return this;
     }

--- a/src/main/java/com/db/tflm/manualcapture/action/InternallyTrackedActionBuilder.java
+++ b/src/main/java/com/db/tflm/manualcapture/action/InternallyTrackedActionBuilder.java
@@ -1,0 +1,69 @@
+package com.db.tflm.manualcapture.action;
+
+import io.gatling.commons.validation.Success;
+import io.gatling.core.action.Action;
+import io.gatling.core.action.RequestAction;
+import io.gatling.core.action.builder.ActionBuilder;
+import io.gatling.core.session.Expression;
+import io.gatling.core.session.Session;
+import io.gatling.core.structure.ScenarioContext;
+import io.gatling.http.request.builder.HttpRequestBuilder;
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+public final class InternallyTrackedActionBuilder extends ActionBuilder {
+    
+    private final Expression<String> requestName;
+    private Optional<BiFunction<ScenarioContext, Action, RequestAction>> requestActionBuilder;
+    private Optional<Tracker> tracker;
+
+    public InternallyTrackedActionBuilder(Expression<String> requestName) {
+        this.requestName = requestName;
+        this.requestActionBuilder = Optional.empty();
+        this.tracker = Optional.empty();
+    }
+
+    public InternallyTrackedActionBuilder requestWithHttp(HttpRequestBuilder httpRequestBuilder) {
+        this.requestActionBuilder = Optional.of((ctx, next) -> 
+            (RequestAction) httpRequestBuilder.build(ctx, next)
+        );
+        return this;
+    }
+
+    public InternallyTrackedActionBuilder trackWith(Tracker tracker) {
+        this.tracker = Optional.of(tracker);
+        return this;
+    }
+
+    public InternallyTrackedActionBuilder trackOnCreatedEvent(Expression<String> transactionId) {
+        this.tracker = Optional.of(new CreatedEventTracker(transactionId));
+        return this;
+    }
+
+    public InternallyTrackedActionBuilder trackOnStatusChangedEvent(Expression<String> transactionId) {
+        this.tracker = Optional.of(new StatusChangedEventTracker(transactionId));
+        return this;
+    }
+
+    @Override
+    public Action build(ScenarioContext ctx, Action next) {
+        RequestAction requestAction = requestActionBuilder
+            .orElseThrow(() -> new IllegalStateException("Request action builder must be set"))
+            .apply(ctx, next);
+            
+        Tracker trackingAction = tracker.orElse(session -> new Success<>(null));
+
+        return new InternallyTrackedAction(
+            requestAction,
+            trackingAction,
+            requestName,
+            ctx,
+            next
+        );
+    }
+
+    public static InternallyTrackedActionBuilder internallyTrackedAction(Expression<String> requestName) {
+        return new InternallyTrackedActionBuilder(requestName);
+    }
+}

--- a/src/main/java/com/db/tflm/manualcapture/action/StatusChangedEventTracker.java
+++ b/src/main/java/com/db/tflm/manualcapture/action/StatusChangedEventTracker.java
@@ -1,0 +1,31 @@
+package com.db.tflm.manualcapture.action;
+
+import io.gatling.commons.validation.Success;
+import io.gatling.commons.validation.Validation;
+import io.gatling.core.session.Expression;
+import io.gatling.core.session.Session;
+
+public class StatusChangedEventTracker implements Tracker {
+    
+    private final Expression<String> transactionId;
+
+    public StatusChangedEventTracker(Expression<String> transactionId) {
+        this.transactionId = transactionId;
+    }
+
+    @Override
+    public Validation<Void> track(Session session) {
+        // Implementation for tracking status changed events
+        // This would typically involve logging or recording the status change
+        // For now, returning success - implement specific tracking logic as needed
+        try {
+            String txnId = transactionId.apply(session).toOption().get();
+            // Add your status changed event tracking logic here
+            // e.g., log the status change, send to monitoring system, etc.
+            
+            return new Success<>(null);
+        } catch (Exception e) {
+            return new io.gatling.commons.validation.Failure(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/db/tflm/manualcapture/action/StatusChangedEventTracker.java
+++ b/src/main/java/com/db/tflm/manualcapture/action/StatusChangedEventTracker.java
@@ -1,5 +1,6 @@
 package com.db.tflm.manualcapture.action;
 
+import io.gatling.commons.validation.Failure;
 import io.gatling.commons.validation.Success;
 import io.gatling.commons.validation.Validation;
 import io.gatling.core.session.Expression;
@@ -25,7 +26,7 @@ public class StatusChangedEventTracker implements Tracker {
             
             return new Success<>(null);
         } catch (Exception e) {
-            return Validation.failure(e.getMessage());
+            return new Failure(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/db/tflm/manualcapture/action/StatusChangedEventTracker.java
+++ b/src/main/java/com/db/tflm/manualcapture/action/StatusChangedEventTracker.java
@@ -25,7 +25,7 @@ public class StatusChangedEventTracker implements Tracker {
             
             return new Success<>(null);
         } catch (Exception e) {
-            return new io.gatling.commons.validation.Failure(e.getMessage());
+            return Validation.failure(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/db/tflm/manualcapture/action/Tracker.java
+++ b/src/main/java/com/db/tflm/manualcapture/action/Tracker.java
@@ -1,0 +1,9 @@
+package com.db.tflm.manualcapture.action;
+
+import io.gatling.commons.validation.Validation;
+import io.gatling.core.session.Session;
+
+@FunctionalInterface
+public interface Tracker {
+    Validation<Void> track(Session session);
+}


### PR DESCRIPTION
Convert Scala Gatling custom action and builder to Java for Java-based simulations.